### PR TITLE
New SraRunTable.txt get

### DIFF
--- a/_episodes/03-ncbi-sra.md
+++ b/_episodes/03-ncbi-sra.md
@@ -50,11 +50,20 @@ has a link to the 224 SRA files for this subproject.
 ["224"](https://www.ncbi.nlm.nih.gov/sra?linkname=bioproject_sra_all&from_uid=295606) and it will take you to the SRA page for this subproject. 
 
 6. For a more organized table, select "Send results to Run selector" at the top of this page. This 
-takes you to the Run Selector page SRP064605 used in the next section. 
+takes you to the Run Selector page SRP064605 used in the next section. The run selector is being updated, at this point you can either use the redesigned SRA Run Selector or revert to the old Run Selector.
 
-## Download the Lenski SRA data from the SRA Run Selector Table
 
-1. Access the Tenaillon dataset from the provided link: [https://trace.ncbi.nlm.nih.gov/Traces/study/?acc=SRP064605](https://trace.ncbi.nlm.nih.gov/Traces/study/?acc=SRP064605).  
+## (Using the Redesigned SRA Run Selector) Download the Lenski SRA data from the SRA Run Selector Table
+
+1. Access the Tenaillon dataset from the provided link: [https://trace.ncbi.nlm.nih.gov/Traces/study/?acc=SRP064605](https://trace.ncbi.nlm.nih.gov/Traces/study/?acc=SRP064605).
+
+2. Under a section marked "Select." You will see there are 312 runs, 109.43 Gb data, and 168.81 Gbases of data Click on "Metadata". 
+
+You should now have a file called `SraRunTable.txt`
+
+## (Reverting to the old Run Selector) Download the Lenski SRA data from the SRA Run Selector Table
+
+1. Access the Tenaillon dataset from the provided link: [https://trace.ncbi.nlm.nih.gov/Traces/study/?acc=SRP064605](https://trace.ncbi.nlm.nih.gov/Traces/study/?acc=SRP064605). Click on "Revert to the old Run Selector" at the top of the page. 
 You will be presented with a page for the overall SRA accession SRP064605 - this is a collection of all the experimental data.
 
 2. Click on the Run Number of the first entry in the bottom table on the page (third table down). This will take you to a page that is a run browser. Take a few minutes to examine some of the descriptions on the page.


### PR DESCRIPTION
Changes in 03-ncbi-sra.md  under the heading "Using the Redesigned SRA Run Selector) Download the Lenski SRA data from the SRA Run Selector Table" which reflects changes in SRA cloud infrastructure. 

Since the NCBI changed the way that the SRA Run Selector works in the update, I've written it two ways. 

references issue #125 