### PR TITLE
replace image with text

### DIFF
--- a/_episodes/03-ncbi-sra.md
+++ b/_episodes/03-ncbi-sra.md
@@ -30,9 +30,17 @@ See the figures below for how information about data access is provided within t
 
 The **above image** shows the title of the study, as well as the authors.
 
-The **image below** shows an excerpt from the paper that includes information on how to locate the sequence data. In this case, the text appears just before the reference section.
+The excerpt from the paper below includes information on how to locate the sequence data. In this case, the text appears just before the reference section.
 
-<img style='border:1px solid #000000' src="../fig/03_acc_info.png" width="800"/>
+> **Author Information** All sequencing data sets are available in the NCBI
+> BioProject database under accession number PRJNA294072. The *breseq*
+> analysis pipeline is available at GitHub ([http://github.com/barricklab/breseq](https://github.com/barricklab/breseq/)).
+> Other analysis scripts are available at the Dryad Digital Repository ([http://dx.doi.org/10.5061/dryad.6226d](https://doi.org/10.5061/dryad.6226d)). R.E.L. will make strains available to qualified
+> recipients, subject to a material transfer agreement. Repreints and permissions
+> information is available at www.nature.com/reprints. The authors declare no
+> competing financial interests. Readers are welcome to comment on the online
+> version of the paper. Correspondence and requests for materials should be
+> addressed to R.E.L. (lenski *at* msu.edu)
 
 **At the beginning of this workshop we gave you [experimental information about these data](http://www.datacarpentry.org/organization-genomics/data/). This lesson uses a *subset* of SRA files, from a small *subproject* of the BioProject database 
 "PRJNA294072". To find these data you can follow the instructions below:** 


### PR DESCRIPTION
Because this image is a text block, it is better to render it as a text block instead of using an image so blind users can understand the content of the block. I've modified the text in two ways:

1. I've replaced the URLs with secure (https) and correct (doi.org) equivalents, but the text will appear the same. 
2. To avoid spamming Dr. Lenski, I modified the email address to remove the `@`. 

This contribution is part of the Core Team accessibility hackathon to add alt-text to images across our lessons. Please feel free to improve upon these suggestions as desired!