### PR TITLE
remove unknown "source" class

### DIFF
--- a/_episodes/02-project-planning.md
+++ b/_episodes/02-project-planning.md
@@ -138,5 +138,4 @@ and asking for help are all valid ways of solving your problems. As you complete
 >
 >L. Welch, F. Lewitter, R. Schwartz, C. Brooksbank, P. Radivojac, B. Gaeta and M. Schneider, '[Bioinformatics Curriculum Guidelines: Toward a Definition of Core Competencies](http://www.ncbi.nlm.nih.gov/pmc/articles/PMC3945096/)', PLoS Comput Biol, vol. 10, no. 3, p. e1003496, 2014.
 >
-> {: .source}
 {: .callout}


### PR DESCRIPTION
This removes a block quote class of `{: .source}`, which does not exist in Carpentries Lessons.

This is urgent because it is necessary to continue working on the transition for this lesson  https://github.com/carpentries/lesson-transition/issues/54