### PR TITLE
update zenodo json for lesson release

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -2,86 +2,60 @@
   "contributors": [
     {
       "type": "Editor",
-      "name": "Roselyn Lemus"
-    },
-    {
-      "type": "Editor",
-      "name": "Mateusz Kuzak",
-      "orcid": "0000-0003-0087-6021"
-    },
-    {
-      "type": "Editor",
-      "name": "Rayna Harris",
-      "orcid": "0000-0002-7943-5650"
-    },
-    {
-      "type": "Editor",
       "name": "Peter Hoyt",
       "orcid": "0000-0002-2767-0923"
+    },
+    {
+      "type": "Editor",
+      "name": "Pauline Karega"
+    },
+    {
+      "type": "Editor",
+      "name": "jcszamosi",
+      "orcid": "0000-0003-2106-0072"
     }
   ],
   "creators": [
     {
-      "name": "Peter R. Hoyt",
+      "name": "Peter Hoyt",
       "orcid": "0000-0002-2767-0923"
     },
     {
-      "name": "Deborah Paul",
-      "orcid": "0000-0003-2639-7520"
+      "name": "Bianca Peterson"
     },
     {
-      "name": "Tracy Teal",
-      "orcid": "0000-0002-9180-9598"
+      "name": "Alana Alexander"
     },
     {
-      "name": "Amanda Charbonneau",
-      "orcid": "0000-0001-7376-7702"
+      "name": "jcszamosi",
+      "orcid": "0000-0003-2106-0072"
     },
     {
-      "name": "Erin Alison Becker",
-      "orcid": "0000-0002-6832-0233"
+      "name": "David Perez-Suarez"
     },
     {
-      "name": "François Michonneau",
-      "orcid": "0000-0002-9092-966X"
+      "name": "Edward Wallace",
+      "orcid": "0000-0001-8025-6361"
     },
     {
-      "name": "Taylor Reiter",
-      "orcid": "0000-0002-7388-421X"
+      "name": "A.C. Schürch",
+      "orcid": "0000-0003-1894-7545"
     },
     {
-      "name": "Rayna Michelle Harris",
-      "orcid": "0000-0002-7943-5650"
+      "name": "Daniel Kerchner",
+      "orcid": "0000-0002-5921-2193"
     },
     {
-      "name": "Toby Hodges",
-      "orcid": "0000-0003-1766-456X"
+      "name": "David Molik"
     },
     {
-      "name": "Jason Williams",
-      "orcid": "0000-0003-3049-2010"
+      "name": "mattbixley"
     },
     {
-      "name": "Bérénice Batut",
-      "orcid": "0000-0001-9852-1987"
+      "name": "Menglan Xiang"
     },
     {
-      "name": "Kevin Weitemier",
-      "orcid": "0000-0002-5793-0343"
-    },
-    {
-      "name": "Laura Williams"
-    },
-    {
-      "name": "Daniel O. S. Ouso",
-      "orcid": "0000-0003-0994-2558"
-    },
-    {
-      "name": "Juan A. Ugalde"
-    },
-    {
-      "name": "Paula Andrea Martinez",
-      "orcid": "0000-0002-8990-1985"
+      "name": "SarahBeecroft"
     }
   ],
   "license": {

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -11,7 +11,7 @@
     },
     {
       "type": "Editor",
-      "name": "jcszamosi",
+      "name": "JCSzamosi",
       "orcid": "0000-0003-2106-0072"
     }
   ],
@@ -27,7 +27,8 @@
       "name": "Alana Alexander"
     },
     {
-      "name": "jcszamosi",
+      "name": "JCS
+zamosi",
       "orcid": "0000-0003-2106-0072"
     },
     {

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -11,7 +11,7 @@
     },
     {
       "type": "Editor",
-      "name": "JCSzamosi",
+      "name": "Jake C. Szamosi",
       "orcid": "0000-0003-2106-0072"
     }
   ],
@@ -27,8 +27,7 @@
       "name": "Alana Alexander"
     },
     {
-      "name": "JCS
-zamosi",
+      "name": "Jake C. Szamosi",
       "orcid": "0000-0003-2106-0072"
     },
     {


### PR DESCRIPTION
updating the `.zenodo.json` with metadata about contributors since last release, in preparation for the infrastructure transition.