### PR TITLE
Link to setup.html throws 404

### DIFF
--- a/learners/setup.md
+++ b/learners/setup.md
@@ -5,6 +5,6 @@ title: Setup
 This workshop is designed to be run on pre-imaged Amazon Web Services
 (AWS) instances. For information about how to
 use the workshop materials, see the
-[setup instructions](https://www.datacarpentry.org/genomics-workshop/setup.html) on the main workshop page.
+[setup instructions](https://www.datacarpentry.org/genomics-workshop/index.html#setup) on the main workshop page.
 
 


### PR DESCRIPTION
There is no setup.html file, and the link throws `404`. The correct link should be https://datacarpentry.org/genomics-workshop/index.html

A similar issue #162 but in the `index.md` file was fixed previously. 

<details>

For more guidance on how to contribute changes to a Carpentries project, please review [the Contributing Guide](CONTRIBUTING.md) and [Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html).

Please keep in mind that lesson Maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum. If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.

</details>
